### PR TITLE
License compliance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,3 +89,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
+This application uses Sage Bionetworks' PDScores task analysis library, which is a
+derivative work (Objective-C port) of MATLAB code created by Max Little and provided 
+under a [Creative Commons Attribution-ShareAlike 3.0](http://creativecommons.org/licenses/by-sa/3.0/legalcode) license.
+


### PR DESCRIPTION
Adding attribution to readme file to comply with CC BY-SA 3.0 license requirements.

Background: Max Little supplied the original MATLAB code for task analysis and scoring under a Creative Commons Attribution-ShareAlike 3.0 license. That license is inappropriate for software (https://wiki.creativecommons.org/Frequently_Asked_Questions#Can_I_apply_a_Creative_Commons_license_to_software.3F) and we're in discussions with Max to re-license it under something like LGPL, but in the meantime this is how we're complying with the existing licensing terms.
